### PR TITLE
Add Python prototype for navigation stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,149 @@
-POLARIS
+# Polaris Navigation Plan
+
+## Prototipo de Código
+
+El repositorio ahora incluye un prototipo mínimo en Python que materializa los
+componentes esenciales descritos en el plan:
+
+| Módulo | Archivo | Descripción |
+| --- | --- | --- |
+| World Model | `polaris_navigation/world_model.py` | `OccupancyGrid` 2D con inflado de obstáculos y utilidades para vecinos/costos. |
+| Global Planner | `polaris_navigation/global_planner.py` | Implementación de A* configurable (heurísticas euclidiana, manhattan y octile). |
+| Trajectory Generator | `polaris_navigation/trajectory_generator.py` | Segmentos polinómicos de mínimo *jerk* en 3D con evaluación de estado. |
+| Feasibility Checker | `polaris_navigation/feasibility_checker.py` | Valida límites de velocidad, aceleración, *jerk* y clearance. |
+| Controller Bridge | `polaris_navigation/controller_bridge.py` | Publicador de setpoints mock compatible con MAVROS. |
+| Supervisor | `polaris_navigation/supervisor.py` | Orquesta planificación global, generación de trayectorias y streaming de setpoints. |
+
+### Ejecución de la demo
+
+```bash
+python -m polaris_navigation.examples.demo
+```
+
+La demo construye un costmap simple, planifica con A*, genera una trayectoria de
+mínimo *jerk*, valida factibilidad (50 Hz) y publica los setpoints resultantes en
+consola.
+
+## 1. Objetivo y Alcance
+- **Objetivo:** planear y ejecutar trayectorias seguras y dinámicamente factibles de A→B con evasión de obstáculos en 2D/3D, integrable con PX4 y MAVROS para facilitar la migración a un dron real. El simulador principal será AirSim.
+- **Alcance inicial (Fase I):** entorno conocido con obstáculos estáticos.
+- **Evolución (Fase II):** entorno parcialmente desconocido, obstáculos dinámicos y replaneamiento en línea.
+
+## 2. Arquitectura de Módulos (ROS 2)
+- **Global Planner (GP):** genera rutas discretas (waypoints) a partir del mapa/ocupación.
+- **Local Planner (LP):** ajusta la trayectoria ante obstáculos cercanos de forma reactiva.
+- **Trajectory Generator (TG):** convierte los waypoints en curvas suaves y factibles (mínimo jerk/snap).
+- **Feasibility Checker (FC):** valida límites dinámicos (velocidad/aceleración/jerk), clearance y colisiones.
+- **Controller Bridge (CB):** publica setpoints a PX4 (posición/velocidad/actitud) vía MAVLink/MAVROS u Offboard.
+- **World Model (WM):** mantiene el mapa estático y la capa de costos dinámica proveniente de sensores.
+- **Supervisor (SUP):** gestiona la misión, dispara replaneos y monitoriza KPIs.
+
+### Temas ROS 2 sugeridos
+- `/mission/goal` (`geometry_msgs/PoseStamped`)
+- `/planner/global_path` (`nav_msgs/Path`)
+- `/planner/local_path` (`nav_msgs/Path`)
+- `/planner/trajectory` (`traj_msgs/PolynomialTrajectory` o mensaje propio)
+- `/world/costmap` (`nav_msgs/OccupancyGrid`) + capa 3D opcional (Octomap/Voxel)
+- `/offboard/setpoint_*` (`mavros_msgs/...`)
+
+## 3. Algoritmos por Componente
+
+### 3.1 Global Planner (Fase I → II)
+- **Fase I (2D/2.5D):** A* en grid (heurística euclídea/octile) con suavizado posterior.
+- **Fase II (3D/continuo):** RRT* o BIT* (OMPL) con costo multicriterio (longitud + riesgo + consumo).
+- **Extensiones:** D* Lite/Anytime D* para cambios locales en el mapa.
+
+### 3.2 Local Planner
+- **Inicio:** DWA o VFH (simple y rápido).
+- **Evolución:** MPC (model predictive control) para respetar la dinámica del UAV y restricciones.
+- **Librerías:** acados, CasADi (usar para ajuste offline si no hay aceleración en vuelo).
+- **Política de prioridad:** el LP manda si hay conflicto inmediato; el GP replanea si el desvío supera un umbral.
+
+### 3.3 Generador de Trayectorias
+- **Método base:** polinomios mínimos de jerk/snap por segmentos (Mellinger & Kumar).
+- **Alternativas:** splines cúbicos/B-splines con continuidad C³.
+- **Salida:** `pos(t)`, `vel(t)`, `acc(t)` a 50–100 Hz.
+
+### 3.4 Colisión y Factibilidad
+- **Chequeo de colisión 2D:** inflado por el radio del dron en el costmap.
+- **Chequeo de colisión 3D:** FCL (Flexible Collision Library) sobre voxel/Octomap/Voxblox.
+- **Dinámica:** límites de `v_max`, `a_max`, `j_max`, `yaw_rate`, `banking angle`.
+- **Clearance dinámica:** margen dependiente de la velocidad (mayor velocidad ⇒ mayor margen).
+
+## 4. Representación del Mundo (WM)
+- **Fase I:** `OccupancyGrid` 2D + capa de costos con inflación.
+- **Fase II:** voxel/OctoMap o Voxblox (ESDF) para planificación 3D suave.
+- **Percepción:** fusión de Lidar/Depth/OAK-D (VIO) + IMU.
+- **SLAM sugerido:** ORB-SLAM3 (mono/estéreo-inercial) u OpenVSLAM; para malla/ESDF: Voxblox.
+
+## 5. Integración con PX4
+- **Modo:** Offboard vía MAVROS/microRTPS.
+- **Control:** envío de setpoints en posición/velocidad + yaw/yaw_rate; fallback a altitude hold/RTL.
+- **Frecuencia:** 20–50 Hz de setpoints estables (reloj estable ⇒ bajo jitter).
+- **Seguridad:** geofence, pérdida de señal, failsafe de batería.
+
+## 6. Tooling y Librerías Recomendadas
+- OMPL (Global planner: RRT*, BIT*, PRM*).
+- Eigen (álgebra).
+- FCL (colisiones).
+- CasADi / acados (MPC y optimización).
+- OctoMap / Voxblox (mapa 3D).
+- PCL/OpenCV (percepción).
+- `rclcpp`, `nav_msgs`, `geometry_msgs` (ROS 2).
+
+## 7. Simulación y Datos
+- **Simulación:**
+  - Gazebo (Ignition) para dinámica UAV clásica.
+  - AirSim si se requiere realismo visual para visión/SLAM.
+- **Datasets:** EuRoC MAV (VI-SLAM), TUM RGB-D, secuencias propias con OAK-D.
+
+## 8. Fases de Entrega y Criterios de Aceptación
+
+### Fase I — Entorno conocido, estático (4–6 semanas)
+1. **GP A*** en grid 2D  
+   *DoD:* genera path sin colisiones con longitud ≤ 1.2× el óptimo en mapas de prueba.
+2. **TG polinómico mínimo jerk**  
+   *DoD:* continuidad C³, límites de velocidad/aceleración respetados, muestreo estable a 50 Hz.
+3. **CB a PX4 + vuelo en SITL**  
+   *DoD:* seguimiento con error medio < 0.5 m y pico < 1.2 m en circuito simple.
+4. **SUP + reintentos**  
+   *DoD:* sin intervención del LP, alcanza el objetivo con ≥ 95% de éxito en 20 corridas.
+
+### Fase II — Obstáculos dinámicos + replaneo (6–10 semanas)
+1. **LP DWA/VFH**  
+   *DoD:* evita intrusos emergentes a ≥ 2 m con ≤ 10% de abortos.
+2. **Replaneo (D* Lite o A* incremental)**  
+   *DoD:* latencia < 200 ms en mapas medianos; ratio de éxito ≥ 90%.
+3. **Opcional: MPC local**  
+   *DoD:* mejora ≥ 20% la suavidad (jerk promedio) y ≤ 10% de tiempo adicional vs. DWA.
+
+## 9. Métricas (KPIs)
+- **Seguridad:** colisiones = 0; clearance mínima ≥ margen configurado.
+- **Desempeño:** tiempo de misión, longitud de ruta, energía estimada.
+- **Calidad:** jerk medio, suavidad de yaw, overshoot.
+- **Robustez:** éxito en N escenarios (≥ 50 corridas Monte Carlo), MTBF de misión.
+- **Cómputo:** uso de CPU/GPU, latencias (planner/tg/control loop).
+
+## 10. Interfaces y Mensajes
+- **Entradas:**
+  - `/mission/goal` (`PoseStamped`)
+  - `/world/costmap` (`OccupancyGrid`) + `/world/esdf` opcional
+  - `/odom` (`nav_msgs/Odometry`), `/imu`
+- **Salidas:**
+  - `/planner/global_path` (`Path`)
+  - `/planner/local_path` (`Path`)
+  - `/planner/trajectory` (mensaje propio con coeficientes polinomiales)
+  - `/offboard/setpoint_position` o `/offboard/setpoint_velocity` (MAVROS)
+
+## 11. Gestión de Riesgos
+- Desfase de reloj: usar `use_sim_time`/NTP; timeouts estrictos en Offboard.
+- Mapas inconsistentes: invalidación por timestamp y confianza (probabilístico).
+- Ruido/latencia de sensores: filtros (EKF/UKF), rechazo de outliers, compuertas de Mahalanobis.
+- Fallas de replaneo: zonas seguras/hover, RTL o aterrizaje controlado.
+
+## 12. Referencias Técnicas
+- Mellinger & Kumar, *Minimum Snap Trajectory Generation for Quadrotors*.
+- LaValle, *Planning Algorithms* (fundamentos A*, RRT).
+- Documentación de OMPL (RRT*, BIT*).
+- Voxblox (ESDF para UAV).
+- PX4 Offboard & MAVROS (setpoints y modos).

--- a/polaris_navigation/__init__.py
+++ b/polaris_navigation/__init__.py
@@ -1,0 +1,25 @@
+"""Polaris navigation stack prototype implementations."""
+
+from .global_planner import AStarPlanner
+from .trajectory_generator import generate_minimum_jerk_trajectory, MinimumJerkSegment
+from .feasibility_checker import (
+    TrajectoryFeasibilityChecker,
+    FeasibilityViolation,
+    FeasibilityLimits,
+)
+from .world_model import OccupancyGrid
+from .controller_bridge import SetpointPublisher
+from .supervisor import MissionSupervisor, MissionGoal
+
+__all__ = [
+    "AStarPlanner",
+    "MinimumJerkSegment",
+    "generate_minimum_jerk_trajectory",
+    "TrajectoryFeasibilityChecker",
+    "FeasibilityViolation",
+    "FeasibilityLimits",
+    "OccupancyGrid",
+    "SetpointPublisher",
+    "MissionSupervisor",
+    "MissionGoal",
+]

--- a/polaris_navigation/controller_bridge.py
+++ b/polaris_navigation/controller_bridge.py
@@ -1,0 +1,35 @@
+"""Controller bridge abstractions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+
+@dataclass
+class Setpoint:
+    position: Tuple[float, float, float]
+    velocity: Tuple[float, float, float]
+    yaw: float = 0.0
+    yaw_rate: float = 0.0
+
+
+class SetpointPublisher:
+    """Mock setpoint publisher emulating a MAVROS offboard interface."""
+
+    def __init__(self, publish_callback: callable | None = None) -> None:
+        self.publish_callback = publish_callback
+        self.published: list[Setpoint] = []
+
+    def publish(self, setpoint: Setpoint) -> None:
+        self.published.append(setpoint)
+        if self.publish_callback is not None:
+            self.publish_callback(setpoint)
+
+    def publish_trajectory(
+        self,
+        samples: Sequence[Tuple[Tuple[float, float, float], Tuple[float, float, float]]],
+        yaw: float = 0.0,
+    ) -> None:
+        for position, velocity in samples:
+            self.publish(Setpoint(position=position, velocity=velocity, yaw=yaw))

--- a/polaris_navigation/examples/demo.py
+++ b/polaris_navigation/examples/demo.py
@@ -1,0 +1,44 @@
+"""Example pipeline showing the Polaris navigation components working together."""
+
+from __future__ import annotations
+
+from polaris_navigation import (
+    AStarPlanner,
+    FeasibilityLimits,
+    MissionGoal,
+    MissionSupervisor,
+    OccupancyGrid,
+    SetpointPublisher,
+    TrajectoryFeasibilityChecker,
+)
+
+
+def main() -> None:
+    grid = OccupancyGrid(width=10, height=6, resolution=1.0)
+    grid.set_obstacles({(3, y) for y in range(1, 5)} - {(3, 3)})
+
+    planner = AStarPlanner()
+
+    limits = FeasibilityLimits(
+        max_velocity=2.0,
+        max_acceleration=3.0,
+        max_jerk=10.0,
+        min_clearance=0.2,
+    )
+
+    feasibility_checker = TrajectoryFeasibilityChecker(limits)
+
+    controller = SetpointPublisher(lambda sp: print(f"Setpoint: {sp}"))
+
+    supervisor = MissionSupervisor(grid, planner, feasibility_checker, controller)
+
+    start = (0, 0)
+    goal = MissionGoal(position=(9, 5))
+
+    path = supervisor.execute_mission(start, goal)
+    print("Planned path:", path)
+    print(grid.to_ascii(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/polaris_navigation/feasibility_checker.py
+++ b/polaris_navigation/feasibility_checker.py
@@ -1,0 +1,91 @@
+"""Trajectory feasibility checking utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+from .trajectory_generator import MinimumJerkSegment
+
+
+@dataclass
+class FeasibilityLimits:
+    max_velocity: float
+    max_acceleration: float
+    max_jerk: float
+    min_clearance: float
+
+
+@dataclass
+class FeasibilityViolation(Exception):
+    message: str
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+
+class TrajectoryFeasibilityChecker:
+    """Validate trajectories against dynamic and clearance constraints."""
+
+    def __init__(
+        self,
+        limits: FeasibilityLimits,
+        clearance_function: callable | None = None,
+    ) -> None:
+        self.limits = limits
+        self.clearance_function = clearance_function
+
+    def check(
+        self,
+        trajectory: Sequence[Tuple[MinimumJerkSegment, MinimumJerkSegment, MinimumJerkSegment]],
+        sample_rate: float,
+    ) -> None:
+        """Raise :class:`FeasibilityViolation` if the trajectory violates limits."""
+
+        if sample_rate <= 0:
+            raise ValueError("Sample rate must be positive")
+
+        dt = 1.0 / sample_rate
+
+        for segments in trajectory:
+            duration = segments[0].duration
+            t = 0.0
+            prev_velocity = None
+            prev_acceleration = None
+            while t <= duration + 1e-6:
+                state = [seg.evaluate(min(t, duration)) for seg in segments]
+                position = tuple(component[0] for component in state)
+                velocity = tuple(component[1] for component in state)
+                acceleration = tuple(component[2] for component in state)
+
+                speed = sum(v**2 for v in velocity) ** 0.5
+                if speed > self.limits.max_velocity + 1e-6:
+                    raise FeasibilityViolation(
+                        f"Velocity limit exceeded: {speed:.2f} m/s > {self.limits.max_velocity:.2f}"
+                    )
+
+                accel_norm = sum(a**2 for a in acceleration) ** 0.5
+                if accel_norm > self.limits.max_acceleration + 1e-6:
+                    raise FeasibilityViolation(
+                        f"Acceleration limit exceeded: {accel_norm:.2f} m/s^2 > {self.limits.max_acceleration:.2f}"
+                    )
+
+                if prev_velocity is not None and prev_acceleration is not None:
+                    jerk = sum(
+                        (acceleration[i] - prev_acceleration[i]) ** 2 for i in range(3)
+                    ) ** 0.5 / dt
+                    if jerk > self.limits.max_jerk + 1e-6:
+                        raise FeasibilityViolation(
+                            f"Jerk limit exceeded: {jerk:.2f} m/s^3 > {self.limits.max_jerk:.2f}"
+                        )
+
+                if self.clearance_function is not None:
+                    clearance = self.clearance_function(position)
+                    if clearance < self.limits.min_clearance:
+                        raise FeasibilityViolation(
+                            f"Clearance {clearance:.2f} m below minimum {self.limits.min_clearance:.2f}"
+                        )
+
+                prev_velocity = velocity
+                prev_acceleration = acceleration
+                t += dt

--- a/polaris_navigation/global_planner.py
+++ b/polaris_navigation/global_planner.py
@@ -1,0 +1,93 @@
+"""Grid-based global planner implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from heapq import heappop, heappush
+from typing import Dict, List, Optional, Tuple
+
+from .world_model import OccupancyGrid
+
+
+@dataclass(order=True)
+class PriorityNode:
+    """Node wrapper that enables priority queue ordering by total cost."""
+
+    priority: float
+    position: Tuple[int, int] = field(compare=False)
+
+
+class AStarPlanner:
+    """A* planner that operates on a 2D occupancy grid."""
+
+    def __init__(self, heuristic: str = "euclidean") -> None:
+        self.heuristic = heuristic
+
+    def plan(
+        self,
+        grid: OccupancyGrid,
+        start: Tuple[int, int],
+        goal: Tuple[int, int],
+        allow_diagonal: bool = True,
+    ) -> List[Tuple[int, int]]:
+        """Plan a collision-free path on the grid from start to goal.
+
+        Args:
+            grid: OccupancyGrid containing obstacle data.
+            start: Starting cell index (x, y).
+            goal: Goal cell index (x, y).
+            allow_diagonal: Whether to allow diagonal moves.
+
+        Returns:
+            List of grid coordinates from start to goal inclusive.
+
+        Raises:
+            ValueError: If start/goal invalid or path not found.
+        """
+
+        if not grid.is_index_valid(start) or not grid.is_index_valid(goal):
+            raise ValueError("Start or goal is outside of the grid bounds")
+        if grid.is_occupied(start) or grid.is_occupied(goal):
+            raise ValueError("Start or goal cell is occupied")
+
+        open_set: List[PriorityNode] = []
+        heappush(open_set, PriorityNode(0.0, start))
+
+        came_from: Dict[Tuple[int, int], Optional[Tuple[int, int]]] = {start: None}
+        g_score: Dict[Tuple[int, int], float] = {start: 0.0}
+
+        while open_set:
+            current = heappop(open_set).position
+            if current == goal:
+                return self._reconstruct_path(came_from, current)
+
+            for neighbor in grid.neighbors(current, allow_diagonal=allow_diagonal):
+                tentative_g = g_score[current] + grid.cost_between(current, neighbor)
+                if tentative_g < g_score.get(neighbor, float("inf")):
+                    came_from[neighbor] = current
+                    g_score[neighbor] = tentative_g
+                    f_score = tentative_g + self._heuristic(neighbor, goal)
+                    heappush(open_set, PriorityNode(f_score, neighbor))
+
+        raise ValueError("No path found between start and goal")
+
+    def _heuristic(self, node: Tuple[int, int], goal: Tuple[int, int]) -> float:
+        dx = abs(node[0] - goal[0])
+        dy = abs(node[1] - goal[1])
+        if self.heuristic == "manhattan":
+            return float(dx + dy)
+        if self.heuristic == "octile":
+            return float(max(dx, dy) + (2**0.5 - 1) * min(dx, dy))
+        return float((dx**2 + dy**2) ** 0.5)
+
+    @staticmethod
+    def _reconstruct_path(
+        came_from: Dict[Tuple[int, int], Optional[Tuple[int, int]]],
+        current: Tuple[int, int],
+    ) -> List[Tuple[int, int]]:
+        path: List[Tuple[int, int]] = [current]
+        while came_from[current] is not None:
+            current = came_from[current]
+            path.append(current)
+        path.reverse()
+        return path

--- a/polaris_navigation/supervisor.py
+++ b/polaris_navigation/supervisor.py
@@ -1,0 +1,82 @@
+"""Mission supervisor tying together the planning stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+from .controller_bridge import SetpointPublisher
+from .feasibility_checker import TrajectoryFeasibilityChecker
+from .global_planner import AStarPlanner
+from .trajectory_generator import generate_minimum_jerk_trajectory
+from .world_model import OccupancyGrid
+
+
+@dataclass
+class MissionGoal:
+    position: Tuple[int, int]
+
+
+class MissionSupervisor:
+    """Orchestrates the global plan, trajectory generation, and setpoint streaming."""
+
+    def __init__(
+        self,
+        grid: OccupancyGrid,
+        planner: AStarPlanner,
+        feasibility_checker: TrajectoryFeasibilityChecker,
+        controller: SetpointPublisher,
+    ) -> None:
+        self.grid = grid
+        self.planner = planner
+        self.feasibility_checker = feasibility_checker
+        self.controller = controller
+
+    def execute_mission(
+        self,
+        start: Tuple[int, int],
+        goal: MissionGoal,
+        altitude: float = 2.0,
+        cruise_speed: float = 1.0,
+    ) -> List[Tuple[int, int]]:
+        """Plan, verify, and stream a trajectory to the controller."""
+
+        path = self.planner.plan(self.grid, start, goal.position)
+
+        waypoints = [
+            (self.grid.index_to_world(cell)[0], self.grid.index_to_world(cell)[1], altitude)
+            for cell in path
+        ]
+
+        segment_times = [
+            max(2.5, 2.0 * self.grid.resolution / max(cruise_speed, 1e-3))
+            for _ in range(len(waypoints) - 1)
+        ]
+        trajectory = generate_minimum_jerk_trajectory(waypoints, segment_times)
+
+        self.feasibility_checker.check(trajectory, sample_rate=50.0)
+
+        samples = []
+        for segments in trajectory:
+            duration = segments[0].duration
+            t = 0.0
+            dt = duration / 10
+            while t <= duration + 1e-6:
+                state = [seg.evaluate(min(t, duration)) for seg in segments]
+                position = tuple(component[0] for component in state)
+                velocity = tuple(component[1] for component in state)
+                samples.append((position, velocity))
+                t += dt
+
+        self.controller.publish_trajectory(samples)
+        return path
+
+
+# Extend OccupancyGrid with conversion helper
+
+def _index_to_world(self: OccupancyGrid, cell: Tuple[int, int]) -> Tuple[float, float]:
+    x, y = cell
+    return (x + 0.5) * self.resolution, (y + 0.5) * self.resolution
+
+
+OccupancyGrid.index_to_world = _index_to_world  # type: ignore[attr-defined]

--- a/polaris_navigation/trajectory_generator.py
+++ b/polaris_navigation/trajectory_generator.py
@@ -1,0 +1,121 @@
+"""Trajectory generation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+
+@dataclass
+class MinimumJerkSegment:
+    """Polynomial segment for minimum-jerk motion in 1D."""
+
+    coefficients: Tuple[float, float, float, float, float, float]
+    duration: float
+
+    def evaluate(self, t: float) -> Tuple[float, float, float]:
+        """Evaluate position, velocity, and acceleration at time t."""
+
+        if t < 0 or t > self.duration:
+            raise ValueError("Time t must be within the segment duration")
+        a0, a1, a2, a3, a4, a5 = self.coefficients
+        position = a0 + a1 * t + a2 * t**2 + a3 * t**3 + a4 * t**4 + a5 * t**5
+        velocity = (
+            a1
+            + 2 * a2 * t
+            + 3 * a3 * t**2
+            + 4 * a4 * t**3
+            + 5 * a5 * t**4
+        )
+        acceleration = (
+            2 * a2
+            + 6 * a3 * t
+            + 12 * a4 * t**2
+            + 20 * a5 * t**3
+        )
+        return position, velocity, acceleration
+
+
+def _minimum_jerk_coefficients(
+    start: Tuple[float, float, float],
+    end: Tuple[float, float, float],
+    duration: float,
+) -> Tuple[float, float, float, float, float, float]:
+    """Solve for the coefficients of a 5th-order polynomial."""
+
+    if duration <= 0:
+        raise ValueError("Duration must be positive")
+
+    p0, v0, a0 = start
+    pf, vf, af = end
+
+    T = duration
+    T2 = T**2
+    T3 = T**3
+    T4 = T**4
+    T5 = T**5
+
+    a0_coef = p0
+    a1_coef = v0
+    a2_coef = 0.5 * a0
+
+    c0 = pf - (p0 + v0 * T + 0.5 * a0 * T2)
+    c1 = vf - (v0 + a0 * T)
+    c2 = af - a0
+
+    a3_coef = (10 * c0 - 4 * c1 + 0.5 * c2) / T3
+    a4_coef = (-15 * c0 + 7 * c1 - c2) / T4
+    a5_coef = (6 * c0 - 3 * c1 + 0.5 * c2) / T5
+
+    return a0_coef, a1_coef, a2_coef, a3_coef, a4_coef, a5_coef
+
+
+def generate_minimum_jerk_trajectory(
+    waypoints: Sequence[Tuple[float, float, float]],
+    times: Sequence[float],
+    start_velocity: Tuple[float, float, float] | None = None,
+    end_velocity: Tuple[float, float, float] | None = None,
+) -> List[Tuple[MinimumJerkSegment, MinimumJerkSegment, MinimumJerkSegment]]:
+    """Generate a 3D minimum-jerk trajectory across waypoints.
+
+    Args:
+        waypoints: Sequence of 3D positions.
+        times: Segment durations for each waypoint transition.
+        start_velocity: Optional starting velocity vector.
+        end_velocity: Optional ending velocity vector.
+
+    Returns:
+        List of tuples containing per-axis polynomial segments.
+    """
+
+    if len(waypoints) < 2:
+        raise ValueError("At least two waypoints are required")
+    if len(times) != len(waypoints) - 1:
+        raise ValueError("Times must have length len(waypoints) - 1")
+
+    trajectory: List[
+        Tuple[MinimumJerkSegment, MinimumJerkSegment, MinimumJerkSegment]
+    ] = []
+
+    prev_velocity = start_velocity or (0.0, 0.0, 0.0)
+
+    for idx in range(len(waypoints) - 1):
+        start = waypoints[idx]
+        end = waypoints[idx + 1]
+        duration = times[idx]
+
+        next_velocity = (
+            end_velocity if idx == len(waypoints) - 2 and end_velocity is not None else prev_velocity
+        )
+
+        segments: List[MinimumJerkSegment] = []
+        for axis in range(3):
+            coeffs = _minimum_jerk_coefficients(
+                start=(start[axis], prev_velocity[axis], 0.0),
+                end=(end[axis], next_velocity[axis], 0.0),
+                duration=duration,
+            )
+            segments.append(MinimumJerkSegment(coefficients=coeffs, duration=duration))
+        trajectory.append(tuple(segments))
+
+    return trajectory

--- a/polaris_navigation/world_model.py
+++ b/polaris_navigation/world_model.py
@@ -1,0 +1,105 @@
+"""World model primitives for occupancy-based planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Sequence, Tuple
+
+
+@dataclass
+class OccupancyGrid:
+    """A simple 2D occupancy grid with inflation utilities."""
+
+    width: int
+    height: int
+    resolution: float = 1.0
+
+    def __post_init__(self) -> None:
+        self._data: List[int] = [0] * (self.width * self.height)
+
+    def index(self, cell: Tuple[int, int]) -> int:
+        x, y = cell
+        return y * self.width + x
+
+    def is_index_valid(self, cell: Tuple[int, int]) -> bool:
+        x, y = cell
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def set_obstacle(self, cell: Tuple[int, int]) -> None:
+        if self.is_index_valid(cell):
+            self._data[self.index(cell)] = 1
+
+    def clear_obstacle(self, cell: Tuple[int, int]) -> None:
+        if self.is_index_valid(cell):
+            self._data[self.index(cell)] = 0
+
+    def is_occupied(self, cell: Tuple[int, int]) -> bool:
+        if not self.is_index_valid(cell):
+            return True
+        return self._data[self.index(cell)] > 0
+
+    def inflate(self, radius: int) -> None:
+        """Inflate obstacles by a given radius in grid cells."""
+
+        if radius <= 0:
+            return
+        original = self._data[:]
+        for x in range(self.width):
+            for y in range(self.height):
+                if original[self.index((x, y))] > 0:
+                    for nx in range(x - radius, x + radius + 1):
+                        for ny in range(y - radius, y + radius + 1):
+                            if self.is_index_valid((nx, ny)):
+                                self._data[self.index((nx, ny))] = 1
+
+    def neighbors(
+        self, cell: Tuple[int, int], allow_diagonal: bool = True
+    ) -> Iterator[Tuple[int, int]]:
+        steps: Sequence[Tuple[int, int]]
+        if allow_diagonal:
+            steps = (
+                (-1, 0),
+                (1, 0),
+                (0, -1),
+                (0, 1),
+                (-1, -1),
+                (-1, 1),
+                (1, -1),
+                (1, 1),
+            )
+        else:
+            steps = ((-1, 0), (1, 0), (0, -1), (0, 1))
+
+        for dx, dy in steps:
+            neighbor = (cell[0] + dx, cell[1] + dy)
+            if self.is_index_valid(neighbor) and not self.is_occupied(neighbor):
+                yield neighbor
+
+    def cost_between(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        dx = abs(a[0] - b[0])
+        dy = abs(a[1] - b[1])
+        if dx == 1 and dy == 1:
+            return 2 ** 0.5
+        return 1.0
+
+    def set_obstacles(self, cells: Iterable[Tuple[int, int]]) -> None:
+        for cell in cells:
+            self.set_obstacle(cell)
+
+    def to_ascii(self, path: Sequence[Tuple[int, int]] | None = None) -> str:
+        """Render an ASCII representation of the grid with an optional path."""
+
+        path_set = set(path or [])
+        rows: List[str] = []
+        for y in range(self.height):
+            row = []
+            for x in range(self.width):
+                cell = (x, y)
+                if cell in path_set:
+                    row.append("*")
+                elif self.is_occupied(cell):
+                    row.append("#")
+                else:
+                    row.append(".")
+            rows.append("".join(row))
+        return "\n".join(rows)


### PR DESCRIPTION
## Summary
- implement Python modules for the occupancy grid, A* global planner, minimum-jerk trajectory generation, feasibility checks, controller bridge, and mission supervisor described in the README
- add an executable demo that runs the end-to-end planning and setpoint publication pipeline
- document the prototype and demo command in the README and ignore generated Python bytecode

## Testing
- python -m polaris_navigation.examples.demo

------
https://chatgpt.com/codex/tasks/task_e_68d655acb9288323a08ffd53b8ef875b